### PR TITLE
Add --bindAddress to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ java -jar aws-smtp-relay.jar
 ### Arguments
 ```
 usage: aws-smtp-relay
+ -b,--bindAddress <arg>     Address to listen to
  -c,--configuration <arg>   AWS SES configuration to use
  -h,--help                  Display this help
  -p,--port <arg>            Port number to listen to

--- a/src/main/java/com/loopingz/AwsSmtpRelay.java
+++ b/src/main/java/com/loopingz/AwsSmtpRelay.java
@@ -67,7 +67,7 @@ public class AwsSmtpRelay implements SimpleMessageListener {
     public static void main(String[] args) throws UnknownHostException {
         Options options = new Options();
         options.addOption("p", "port", true, "Port number to listen to");
-        options.addOption("b", "bindAddress", true, "bind address");
+        options.addOption("b", "bindAddress", true, "Address to listen to");
         options.addOption("r", "region", true, "AWS region to use");
         options.addOption("c","configuration", true, "AWS SES configuration to use");
         options.addOption("h","help", false, "Display this help");

--- a/src/main/java/com/loopingz/AwsSmtpRelay.java
+++ b/src/main/java/com/loopingz/AwsSmtpRelay.java
@@ -69,8 +69,8 @@ public class AwsSmtpRelay implements SimpleMessageListener {
         options.addOption("p", "port", true, "Port number to listen to");
         options.addOption("b", "bindAddress", true, "Address to listen to");
         options.addOption("r", "region", true, "AWS region to use");
-        options.addOption("c","configuration", true, "AWS SES configuration to use");
-        options.addOption("h","help", false, "Display this help");
+        options.addOption("c", "configuration", true, "AWS SES configuration to use");
+        options.addOption("h", "help", false, "Display this help");
         try {
             CommandLineParser parser = new DefaultParser();
             cmd = parser.parse(options, args);
@@ -83,7 +83,7 @@ public class AwsSmtpRelay implements SimpleMessageListener {
             AwsSmtpRelay server = new AwsSmtpRelay();
             server.run();
         } catch (ParseException ex) {
-
+            System.err.println(ex.getMessage());
         }
     }
 }


### PR DESCRIPTION
Hi! Thanks for this great project. I was searching earlier and couldn't find any solutions that worked without SMTP credentials. I've got it running in local kubernetes cluster using AWS env var credentials and will deploy to our k8s cluster.

Please accept this PR as a token of my appreciation! :smiley: 

Adds --bindAddress to README.md and prints error message if a ParserException is thrown (didn't happen to me - but I believe errors shouldn't be silently swallowed).

I might have some k8s resources and add example IAM policy to readme for another PR next week.