### PR TITLE
Use AWS SES API to pass on from and to address

### DIFF
--- a/src/main/java/com/loopingz/AwsSmtpRelay.java
+++ b/src/main/java/com/loopingz/AwsSmtpRelay.java
@@ -43,7 +43,8 @@ public class AwsSmtpRelay implements SimpleMessageListener {
         RawMessage rawMessage =
                 new RawMessage(ByteBuffer.wrap(msg));
         SendRawEmailRequest rawEmailRequest =
-                new SendRawEmailRequest(rawMessage);
+                new SendRawEmailRequest(rawMessage).withSource(from)
+                                                   .withDestinations(to);
         if (cmd.hasOption("c")) {
             rawEmailRequest = rawEmailRequest.withConfigurationSetName(cmd.getOptionValue("c"));
         }


### PR DESCRIPTION
So I took a look at AWS SES Java APIs and found there's a better way to pass on from and to.....

I've wasted a day implementing an inferior solution concatenating bytebuffers... https://github.com/loopingz/aws-smtp-relay/pull/7 :cry:

This is a much nicer and cleaner solution.