### PR TITLE
Simplify dockerfile 2nd attempt

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,10 @@
-FROM maven:alpine
+FROM java
 MAINTAINER Damien Metzler <dmetzler@nuxeo.com>
 MAINTAINER Remi Cattiau <remi@cattiau.com>
 MAINTAINER Morgan Christiansson <docker@mog.se>
 
 ADD target/*-jar-with-dependencies.jar /usr/share/aws-smtp-relay/aws-smtp-relay.jar
 
-
 ENTRYPOINT ["/usr/bin/java", "-jar", "/usr/share/aws-smtp-relay/aws-smtp-relay.jar", "-b", "0.0.0.0"]
+
 EXPOSE 10025

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM java
+FROM openjdk:jre-alpine
 MAINTAINER Damien Metzler <dmetzler@nuxeo.com>
 MAINTAINER Remi Cattiau <remi@cattiau.com>
 MAINTAINER Morgan Christiansson <docker@mog.se>

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,9 @@
 FROM maven:alpine
 MAINTAINER Damien Metzler <dmetzler@nuxeo.com>
 MAINTAINER Remi Cattiau <remi@cattiau.com>
+MAINTAINER Morgan Christiansson <docker@mog.se>
 
-RUN mkdir -p /opt/aws-smtp-relay-src/
-RUN mkdir -p /usr/share/aws-smtp-relay
-ADD . /opt/aws-smtp-relay-src/
-RUN cd /opt/aws-smtp-relay-src/ && mvn package
-RUN cp /opt/aws-smtp-relay-src/target/*-with-dependencies.jar /usr/share/aws-smtp-relay/aws-smtp-relay.jar
+ADD target/*-jar-with-dependencies.jar /usr/share/aws-smtp-relay/aws-smtp-relay.jar
 
 
 ENTRYPOINT ["/usr/bin/java", "-jar", "/usr/share/aws-smtp-relay/aws-smtp-relay.jar", "-b", "0.0.0.0"]

--- a/hooks/pre_build
+++ b/hooks/pre_build
@@ -1,0 +1,7 @@
+#!/bin/bash
+echo "=> Building the binary"
+docker run --privileged \
+  -v $(pwd):/src \
+  -v /var/run/docker.sock:/var/run/docker.sock \
+  --workdir /src \
+  maven:alpine mvn package


### PR DESCRIPTION
Using the included ```hooks/pre_hook``` and docker cloud autobuild (instead of docker hub autobuild which doesn't support [custom build phase hoooks](https://docs.docker.com/docker-cloud/builds/advanced/#override-build-test-or-push-commands)) the project builds correctly and uses openjdk:jre-alpine base image.

The resulting image is [64mb in size](https://hub.docker.com/r/morganchristiansson/aws-smtp-relay/tags/) down from [current 115mb](https://hub.docker.com/r/loopingz/aws-smtp-relay/tags/)  - a 44% reduction.