### PR TITLE
Implemented SourceArn parameter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.idea/
 target/
 pom.xml.tag
 pom.xml.releaseBackup

--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ java -jar aws-smtp-relay.jar
 usage: aws-smtp-relay
  -b,--bindAddress <arg>     Address to listen to
  -c,--configuration <arg>   AWS SES configuration to use
+ -a,--sourceArn <arg>       AWS ARN of the sending authorization policy
  -h,--help                  Display this help
  -p,--port <arg>            Port number to listen to
  -r,--region <arg>          AWS region to use

--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
             <dependency>
                 <groupId>com.amazonaws</groupId>
                 <artifactId>aws-java-sdk-bom</artifactId>
-                <version>1.11.106</version>
+                <version>1.11.449</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
@@ -34,15 +34,17 @@
         <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>aws-java-sdk-dynamodb</artifactId>
+            <version>1.11.449</version>
         </dependency>
         <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>aws-java-sdk-ses</artifactId>
+            <version>1.11.449</version>
         </dependency>
         <dependency>
             <groupId>com.sun.mail</groupId>
             <artifactId>javax.mail</artifactId>
-            <version>1.6.0</version>
+            <version>1.6.2</version>
         </dependency>
         <dependency>
             <groupId>commons-io</groupId>
@@ -62,12 +64,12 @@
         <dependency>
            <groupId>org.slf4j</groupId>
            <artifactId>slf4j-api</artifactId>
-           <version>1.7.5</version>
+           <version>1.7.25</version>
        </dependency>
        <dependency>
            <groupId>org.slf4j</groupId>
            <artifactId>slf4j-simple</artifactId>
-           <version>1.6.4</version>
+           <version>1.7.25</version>
        </dependency>
     </dependencies>
 
@@ -98,7 +100,7 @@
             <plugin>
               <groupId>com.spotify</groupId>
               <artifactId>dockerfile-maven-plugin</artifactId>
-              <version>1.3.7</version>
+              <version>1.4.9</version>
               <configuration>
                 <repository>nuxeo/aws-smtp-relay</repository>
                 <tag>${project.version}</tag>

--- a/src/main/java/com/loopingz/AwsSmtpRelay.java
+++ b/src/main/java/com/loopingz/AwsSmtpRelay.java
@@ -44,6 +44,9 @@ public class AwsSmtpRelay implements SimpleMessageListener {
         SendRawEmailRequest rawEmailRequest =
                 new SendRawEmailRequest(rawMessage).withSource(from)
                                                    .withDestinations(to);
+        if (cmd.hasOption("a")) {
+            rawEmailRequest = rawEmailRequest.withSourceArn(cmd.getOptionValue("a"));
+        }
         if (cmd.hasOption("c")) {
             rawEmailRequest = rawEmailRequest.withConfigurationSetName(cmd.getOptionValue("c"));
         }
@@ -74,6 +77,7 @@ public class AwsSmtpRelay implements SimpleMessageListener {
         options.addOption("b", "bindAddress", true, "Address to listen to");
         options.addOption("r", "region", true, "AWS region to use");
         options.addOption("c", "configuration", true, "AWS SES configuration to use");
+        options.addOption("a", "sourceArn", true, "AWS ARN of the sending authorization policy");
         options.addOption("h", "help", false, "Display this help");
         try {
             CommandLineParser parser = new DefaultParser();


### PR DESCRIPTION
This parameter is used only for sending authorization. It is the ARN of the identity that is associated with the sending authorization policy that permits you to send for the email address specified in the Source parameter.