### PR TITLE
Implemented FromArn parameter

### DIFF
--- a/src/main/java/com/loopingz/AwsSmtpRelay.java
+++ b/src/main/java/com/loopingz/AwsSmtpRelay.java
@@ -44,10 +44,9 @@ public class AwsSmtpRelay implements SimpleMessageListener {
         SendRawEmailRequest rawEmailRequest =
                 new SendRawEmailRequest(rawMessage).withSource(from)
                                                    .withDestinations(to);
-        if (cmd.hasOption("a")) {
-            rawEmailRequest = rawEmailRequest.withSourceArn(cmd.getOptionValue("a"))
-                    .withFromArn(cmd.getOptionValue("a"))
-                    .withReturnPathArn(cmd.getOptionValue("a"));
+        if (cmd.hasOption("s")) {
+            rawEmailRequest = rawEmailRequest.withSourceArn(cmd.getOptionValue("s"))
+                    .withFromArn(cmd.getOptionValue("s"));
         }
         if (cmd.hasOption("c")) {
             rawEmailRequest = rawEmailRequest.withConfigurationSetName(cmd.getOptionValue("c"));
@@ -79,7 +78,7 @@ public class AwsSmtpRelay implements SimpleMessageListener {
         options.addOption("b", "bindAddress", true, "Address to listen to");
         options.addOption("r", "region", true, "AWS region to use");
         options.addOption("c", "configuration", true, "AWS SES configuration to use");
-        options.addOption("a", "identityArn", true, "AWS identity ARN associated with the sending authorization policy");
+        options.addOption("s", "sourceArn", true, "AWS identity ARN associated with the sending authorization policy");
         options.addOption("h", "help", false, "Display this help");
         try {
             CommandLineParser parser = new DefaultParser();

--- a/src/main/java/com/loopingz/AwsSmtpRelay.java
+++ b/src/main/java/com/loopingz/AwsSmtpRelay.java
@@ -45,7 +45,9 @@ public class AwsSmtpRelay implements SimpleMessageListener {
                 new SendRawEmailRequest(rawMessage).withSource(from)
                                                    .withDestinations(to);
         if (cmd.hasOption("a")) {
-            rawEmailRequest = rawEmailRequest.withSourceArn(cmd.getOptionValue("a"));
+            rawEmailRequest = rawEmailRequest.withSourceArn(cmd.getOptionValue("a"))
+                    .withFromArn(cmd.getOptionValue("a"))
+                    .withReturnPathArn(cmd.getOptionValue("a"));
         }
         if (cmd.hasOption("c")) {
             rawEmailRequest = rawEmailRequest.withConfigurationSetName(cmd.getOptionValue("c"));
@@ -77,7 +79,7 @@ public class AwsSmtpRelay implements SimpleMessageListener {
         options.addOption("b", "bindAddress", true, "Address to listen to");
         options.addOption("r", "region", true, "AWS region to use");
         options.addOption("c", "configuration", true, "AWS SES configuration to use");
-        options.addOption("a", "sourceArn", true, "AWS ARN of the sending authorization policy");
+        options.addOption("a", "identityArn", true, "AWS identity ARN associated with the sending authorization policy");
         options.addOption("h", "help", false, "Display this help");
         try {
             CommandLineParser parser = new DefaultParser();


### PR DESCRIPTION
The ARN of the identity that is associated with the sending authorization policy that permits you to specify a particular "From" address in the header of the raw email.

Only specifying a SourceArn does not seem sufficient with applications that implement a "from:" header, see: https://github.com/loopingz/aws-smtp-relay/issues/16#issuecomment-439482964

Background:
https://docs.aws.amazon.com/ses/latest/DeveloperGuide/sending-authorization-delegate-sender-tasks-email.html
