### PR TITLE
Send temporary SMTP error code whenever the cause isn't the client

### DIFF
--- a/src/main/java/com/loopingz/AwsSmtpRelay.java
+++ b/src/main/java/com/loopingz/AwsSmtpRelay.java
@@ -13,6 +13,7 @@ import org.subethamail.smtp.helper.SimpleMessageListener;
 import org.subethamail.smtp.helper.SimpleMessageListenerAdapter;
 import org.subethamail.smtp.server.SMTPServer;
 
+import com.amazonaws.AmazonServiceException.ErrorType;
 import com.amazonaws.services.simpleemail.AmazonSimpleEmailService;
 import com.amazonaws.services.simpleemail.AmazonSimpleEmailServiceClientBuilder;
 import com.amazonaws.services.simpleemail.model.AmazonSimpleEmailServiceException;
@@ -53,7 +54,12 @@ public class AwsSmtpRelay implements SimpleMessageListener {
         try {
             client.sendRawEmail(rawEmailRequest);
         } catch (AmazonSimpleEmailServiceException e) {
-            throw new RejectException(e.getMessage());
+            if(e.getErrorType() == ErrorType.Client) {
+                // If it's a client error, return a permanent error
+                throw new RejectException(e.getMessage());
+            } else {
+                throw new RejectException(451, e.getMessage());
+            }
         }
     }
 


### PR DESCRIPTION
## Fixes

At present, the SMTP relay always returns a permanent failure code. This causes SMTP clients not to retry if the error is transient or server-side. This patch causes the relay to send a temporary error code whenever the error isn't caused by the client.