### PR TITLE
Add smtp override and allow SSM Paramater Store variables for quick change

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .idea/
 target/
+*.iml
 pom.xml.tag
 pom.xml.releaseBackup
 pom.xml.versionsBackup

--- a/pom.xml
+++ b/pom.xml
@@ -7,39 +7,40 @@
     <artifactId>aws-smtp-relay</artifactId>
     <version>1.0.0</version>
 
+    <properties>
+        <maven.compiler.source>1.8</maven.compiler.source>
+        <maven.compiler.target>1.8</maven.compiler.target>
+    </properties>
+
     <dependencyManagement>
         <dependencies>
             <dependency>
                 <groupId>com.amazonaws</groupId>
                 <artifactId>aws-java-sdk-bom</artifactId>
-                <version>1.11.449</version>
+                <version>1.11.517</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
-            <!-- https://mvnrepository.com/artifact/org.subethamail/subethasmtp -->
             <dependency>
-                <groupId>org.subethamail</groupId>
+                <groupId>com.github.davidmoten</groupId>
                 <artifactId>subethasmtp</artifactId>
-                <version>3.1.7</version>
+                <version>4.0-RC8</version>
             </dependency>
         </dependencies>
     </dependencyManagement>
 
     <dependencies>
         <dependency>
-            <groupId>org.subethamail</groupId>
+            <groupId>com.github.davidmoten</groupId>
             <artifactId>subethasmtp</artifactId>
-            <version>3.1.7</version>
         </dependency>
         <dependency>
             <groupId>com.amazonaws</groupId>
-            <artifactId>aws-java-sdk-dynamodb</artifactId>
-            <version>1.11.473</version>
+            <artifactId>aws-java-sdk-ssm</artifactId>
         </dependency>
         <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>aws-java-sdk-ses</artifactId>
-            <version>1.11.473</version>
         </dependency>
         <dependency>
             <groupId>com.sun.mail</groupId>
@@ -57,11 +58,6 @@
             <version>1.4</version>
         </dependency>
         <dependency>
-            <groupId>commons-cli</groupId>
-            <artifactId>commons-cli</artifactId>
-            <version>1.4</version>
-        </dependency>
-        <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
             <version>1.7.25</version>
@@ -71,6 +67,7 @@
             <artifactId>slf4j-simple</artifactId>
             <version>1.7.25</version>
         </dependency>
+
     </dependencies>
 
     <build>

--- a/pom.xml
+++ b/pom.xml
@@ -10,6 +10,7 @@
     <properties>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
+        <dependency.skip>false</dependency.skip>
     </properties>
 
     <dependencyManagement>
@@ -17,14 +18,14 @@
             <dependency>
                 <groupId>com.amazonaws</groupId>
                 <artifactId>aws-java-sdk-bom</artifactId>
-                <version>1.11.517</version>
+                <version>1.11.522</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
             <dependency>
                 <groupId>com.github.davidmoten</groupId>
                 <artifactId>subethasmtp</artifactId>
-                <version>4.0-RC8</version>
+                <version>4.0.1</version>
             </dependency>
         </dependencies>
     </dependencyManagement>
@@ -78,6 +79,135 @@
             </resource>
         </resources>
         <plugins>
+            <plugin>
+                <groupId>org.owasp</groupId><artifactId>dependency-check-maven</artifactId><version>5.0.0-M2</version>
+                <configuration>
+                    <suppressionFile>${project.basedir}/src/main/config/owasp-dependency-checker-suppressions.xml</suppressionFile>
+                    <failBuildOnCVSS>4</failBuildOnCVSS>
+                    <skip>${dependency.skip}</skip>
+                    <bundleAuditAnalyzerEnabled>false</bundleAuditAnalyzerEnabled>
+                </configuration>
+                <executions>
+                    <execution>
+                        <phase>validate</phase> <!-- too late at prepare-package -->
+                        <goals><goal>check</goal></goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <artifactId>maven-checkstyle-plugin</artifactId>
+                <version>3.0.0</version>
+                <dependencies>
+                    <dependency>
+                        <groupId>com.puppycrawl.tools</groupId>
+                        <artifactId>checkstyle</artifactId>
+                        <version>6.19</version>
+                    </dependency>
+                </dependencies>
+                <configuration>
+                    <includeTestSourceDirectory>true</includeTestSourceDirectory>
+                    <configLocation>${project.basedir}/src/main/config/checkstyle_rules.xml</configLocation>
+                    <propertyExpansion>config.directory=${project.basedir}/src/main/config</propertyExpansion>
+                    <excludes>
+                        node_modules,src/main/webapp/WEB-INF/eligibility-checklist/node_modules,src/main/webapp/WEB-INF/eligibility-checklist/dist.tar.gz
+                    </excludes>
+                </configuration>
+                <executions>
+                    <execution>
+                        <phase>validate</phase> <!-- too late at prepare-package -->
+                        <goals>
+                            <!--<goal>checkstyle</goal>--> <!-- can be checkstyle to not fail the build-->
+                            <goal>check</goal> <!-- make it die if not good -->
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <artifactId>maven-pmd-plugin</artifactId>
+                <version>3.10.0</version>
+                <dependencies>
+                    <dependency>
+                        <groupId>net.sourceforge.pmd</groupId>
+                        <artifactId>pmd-core</artifactId>
+                        <version>6.7.0</version>
+                    </dependency>
+                    <dependency>
+                        <groupId>net.sourceforge.pmd</groupId>
+                        <artifactId>pmd-java</artifactId>
+                        <version>6.7.0</version>
+                    </dependency>
+                </dependencies>
+                <configuration>
+                    <includeTests>false</includeTests>
+                    <rulesets>
+                        <ruleset>/rulesets/java/basic.xml</ruleset>
+                        <ruleset>${project.basedir}/src/main/config/pmd-rules.xml</ruleset>
+                    </rulesets>
+                    <excludeRoots>
+                        <excludeRoot>${project.basedir}/target/generated-sources</excludeRoot>
+                    </excludeRoots>
+                    <printFailingErrors>true</printFailingErrors>
+                </configuration>
+                <executions>
+                    <execution>
+                        <phase>validate</phase> <!-- too late at prepare-package -->
+                        <goals>
+                            <!--<goal>pmd</goal>--> <!--can be pmd be check once we have time to fix all errors-->
+                            <goal>check</goal> <!-- make it die if not good -->
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>findbugs-maven-plugin</artifactId>
+                <version>3.0.4</version>
+                <dependencies>
+                    <dependency>
+                        <groupId>com.google.code.findbugs</groupId>
+                        <artifactId>findbugs</artifactId>
+                        <version>3.0.1</version>
+                    </dependency>
+                    <dependency>
+                        <groupId>com.google.code.findbugs</groupId>
+                        <artifactId>annotations</artifactId>
+                        <version>3.0.1</version>
+                    </dependency>
+                </dependencies>
+                <configuration>
+                    <excludeFilterFile>${project.basedir}/src/main/config/findbugs-exclude.xml</excludeFilterFile>
+                    <effort>Max</effort>
+                    <threshold>High</threshold>
+                    <includeTests>true</includeTests>
+                    <plugins>
+                        <plugin>
+                            <groupId>com.h3xstream.findsecbugs</groupId>
+                            <artifactId>findsecbugs-plugin</artifactId>
+                            <version>1.7.1</version>
+                        </plugin>
+                        <plugin>
+                            <groupId>com.mebigfatguy.fb-contrib</groupId>
+                            <artifactId>fb-contrib</artifactId>
+                            <version>7.4.2</version>
+                        </plugin>
+                        <plugin>
+                            <groupId>org.mutabilitydetector</groupId>
+                            <artifactId>MutabilityDetector4FindBugs</artifactId>
+                            <version>0.9.1</version>
+                        </plugin>
+                    </plugins>
+                </configuration>
+                <executions>
+                    <execution>
+                        <phase>validate</phase> <!-- too late at prepare-package -->
+                        <goals>
+                            <!--<goal>findbugs</goal>--> <!--can be findbugs to not fail the build-->
+                            <goal>check</goal> <!-- make it die if not good -->
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+
             <plugin>
                 <artifactId>maven-assembly-plugin</artifactId>
                 <executions>
@@ -164,4 +294,14 @@
             </plugin>
         </plugins>
     </build>
+    <profiles>
+        <profile>
+            <id>quickrun</id> <!-- to disable pmd/findbugs/owasp check for quick runs mvn ${command} -Pquickrun -->
+            <properties>
+                <dependency.skip>true</dependency.skip>
+                <pmd.skip>true</pmd.skip>
+                <findbugs.skip>true</findbugs.skip>
+            </properties>
+        </profile>
+    </profiles>
 </project>

--- a/src/main/config/checkstyle_rules.xml
+++ b/src/main/config/checkstyle_rules.xml
@@ -1,0 +1,189 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE module PUBLIC
+        "-//Puppy Crawl//DTD Check Configuration 1.3//EN"
+        "http://www.puppycrawl.com/dtds/configuration_1_3.dtd">
+<!--
+    Checkstyle-Configuration: Seniors Concessions CheckStyle
+    Description: none
+-->
+
+<module name="Checker">
+    <!--
+        If you set the basedir property below, then all reported file
+        names will be relative to the specified directory. See
+        http://checkstyle.sourceforge.net/5.x/config.html#Checker
+
+        <property name="basedir" value="${basedir}"/>
+    -->
+
+    <property name="fileExtensions" value="java, properties, xml"/>
+
+    <!-- Allow ignorance -->
+    <module name="SuppressionCommentFilter"/>
+
+    <!-- Checks whether files end with a new line.                        -->
+    <!-- See http://checkstyle.sf.net/config_misc.html#NewlineAtEndOfFile -->
+    <module name="NewlineAtEndOfFile"/>
+
+    <!-- Checks that property files contain the same keys.         -->
+    <!-- See http://checkstyle.sf.net/config_misc.html#Translation -->
+    <module name="Translation"/>
+
+    <module name="FileLength"/>
+
+    <!-- Checks for whitespace                               -->
+    <!-- See http://checkstyle.sf.net/config_whitespace.html -->
+    <module name="FileTabCharacter"/>
+
+    <!-- Miscellaneous other checks.                   -->
+    <!-- See http://checkstyle.sf.net/config_misc.html -->
+    <module name="RegexpSingleline">
+        <property name="format" value="\s+$"/>
+        <property name="minimum" value="0"/>
+        <property name="maximum" value="0"/>
+        <property name="message" value="Line has trailing spaces."/>
+    </module>
+    <module name="RegexpSingleline">
+        <property name="format" value="\S\s\s"/>
+        <property name="message" value="Line has multiple consecutive non-indenting spaces."/>
+    </module>
+    <module name="RegexpSingleline">
+        <property name="format" value="^(  ){0,6} [^ *]"/>
+        <property name="message" value="Odd number of indenting spaces"/>
+    </module>
+    <module name="RegexpSingleline">
+        <property name="format" value="\.getBytes\(\)"/>
+        <property name="message" value="Use 'getBytes(charset)' instead"/>
+    </module>
+    <module name="RegexpSingleline">
+        <property name="format" value="AssertJUnit"/>
+        <property name="message" value="Use standard TestNG Assert instead"/>
+    </module>
+    <module name="RegexpSingleline">
+        <property name="format" value="Charset\.forName.*[Uu][Tt][Ff]-8"/>
+        <property name="message" value="Use 'StandardCharsets.UTF_8' instead"/>
+    </module>
+    <module name="RegexpSingleline">
+        <property name="format" value="\.equals\(&quot;"/>
+        <property name="message" value="Put string literals first in equality comparisons"/>
+    </module>
+    <module name="RegexpSingleline">
+        <property name="format" value="=\s*RequestMethod\.GET\s*\)"/>
+        <property name="message" value="HEAD requests should be allowed along with GET"/>
+    </module>
+    <module name="RegexpMultiline">
+        <property name="format" value="(?&lt;=\n)\n\n"/>
+        <property name="message" value="Multiple consecutive blank lines"/>
+    </module>
+    <module name="RegexpMultiline">
+        <property name="format" value="(?&lt;=\n)\n[ \t]+\}"/>
+        <property name="message" value="Blank line before indented closing brace"/>
+    </module>
+    <module name="RegexpMultiline">
+        <property name="format" value="@Transactional\n*\s*private"/>
+        <property name="message" value="@Transactional cannot be applied to private method"/>
+    </module>
+    <module name="TreeWalker">
+        <module name="FileContentsHolder"/>
+        <!-- Checks for Naming Conventions.                  -->
+        <!-- See http://checkstyle.sf.net/config_naming.html -->
+        <module name="ConstantName"/>
+        <module name="LocalFinalVariableName"/>
+        <module name="LocalVariableName"/>
+        <module name="MemberName"/>
+        <module name="MethodName"/>
+        <module name="PackageName"/>
+        <module name="ParameterName"/>
+        <module name="StaticVariableName"/>
+        <module name="TypeName"/>
+
+        <!-- Checks for imports                              -->
+        <!-- See http://checkstyle.sf.net/config_import.html -->
+        <module name="IllegalImport"/> <!-- defaults to sun.* packages -->
+        <module name="RedundantImport"/>
+        <module name="UnusedImports"/>
+
+        <!-- Checks for Size Violations.                    -->
+        <!-- See http://checkstyle.sf.net/config_sizes.html -->
+        <module name="MethodLength"/>
+        <module name="ParameterNumber">
+            <property name="severity" value="warning"/>
+        </module>
+
+        <!-- Checks for whitespace                               -->
+        <!-- See http://checkstyle.sf.net/config_whitespace.html -->
+        <module name="EmptyForIteratorPad"/>
+        <module name="Indentation">
+            <property name="severity" value="warning"/>
+        </module>
+        <module name="MethodParamPad"/>
+        <module name="NoWhitespaceAfter"/>
+        <module name="NoWhitespaceBefore"/>
+        <module name="OperatorWrap"/>
+        <module name="ParenPad"/>
+        <module name="TypecastParenPad"/>
+        <module name="WhitespaceAfter"/>
+        <module name="WhitespaceAround">
+            <property name="allowEmptyConstructors" value="true"/>
+            <property name="allowEmptyTypes" value="true"/>
+        </module>
+        <module name="EmptyLineSeparator">
+            <property name="tokens" value="METHOD_DEF"/>
+        </module>
+
+        <!-- Modifier Checks                                    -->
+        <!-- See http://checkstyle.sf.net/config_modifiers.html -->
+        <module name="ModifierOrder"/>
+        <module name="RedundantModifier"/>
+
+        <!-- Checks for blocks. You know, those {}'s         -->
+        <!-- See http://checkstyle.sf.net/config_blocks.html -->
+        <module name="AvoidNestedBlocks"/>
+        <module name="EmptyBlock"/>
+        <module name="LeftCurly"/>
+        <module name="NeedBraces"/>
+        <module name="RightCurly"/>
+
+        <!-- Checks for common coding problems               -->
+        <!-- See http://checkstyle.sf.net/config_coding.html -->
+        <module name="EmptyStatement"/>
+        <module name="EqualsHashCode"/>
+        <!-- This would prevent us from naming constructor parameters after fields -->
+        <!--<module name="HiddenField"/>-->
+        <module name="IllegalCatch">
+            <property name="severity" value="warning"/>
+        </module>
+        <module name="IllegalInstantiation"/>
+        <module name="InnerAssignment"/>
+        <module name="MagicNumber">
+            <property name="severity" value="warning"/>
+        </module>
+        <module name="MissingSwitchDefault"/>
+        <module name="SimplifyBooleanExpression"/>
+        <module name="SimplifyBooleanReturn"/>
+
+        <!-- Checks for class design                         -->
+        <!-- See http://checkstyle.sf.net/config_design.html -->
+        <module name="FinalClass"/>
+        <module name="HideUtilityClassConstructor"/>
+        <module name="InterfaceIsType"/>
+        <module name="VisibilityModifier">
+            <property name="protectedAllowed" value="true"/>
+        </module>
+
+        <!-- Miscellaneous other checks.                   -->
+        <!-- See http://checkstyle.sf.net/config_misc.html -->
+        <module name="ArrayTypeStyle"/>
+        <module name="TodoComment"/>
+        <module name="UpperEll"/>
+        <module name="SuperFinalize"/>
+        <module name="SuperClone"/>
+        <module name="StringLiteralEquality"/>
+        <module name="MultipleVariableDeclarations"/>
+    </module>
+
+    <module name="SuppressionFilter">
+        <property name="file" value="${config.directory}/suppressions.xml"/>
+    </module>
+
+</module>

--- a/src/main/config/findbugs-exclude.xml
+++ b/src/main/config/findbugs-exclude.xml
@@ -1,0 +1,26 @@
+<FindBugsFilter>
+    <Match>
+        <!-- We don't care that much about serialization -->
+        <!-- Replacing whitespace manually on every log invocation isn't feasible; maybe implement custom layout? -->
+        <Bug pattern="SE_NO_SERIALVERSIONID,SE_BAD_FIELD,CRLF_INJECTION_LOGS"/>
+    </Match>
+    <Match>
+        <!-- Some fb-contrib filters just aren't production-grade -->
+        <Bug pattern="EXS_EXCEPTION_SOFTENING_NO_CONSTRAINTS,EXS_EXCEPTION_SOFTENING_NO_CHECKED,WEM_WEAK_EXCEPTION_MESSAGING,OPM_OVERLY_PERMISSIVE_METHOD"/>
+    </Match>
+    <Match>
+        <!-- Mockito initialises fields through reflection -->
+        <!-- No need to micro-optimise test performance -->
+        <!-- Tests don't need security checks (eg encrypted sockets) -->
+        <Or>
+            <Class name="~..*Test$"/>
+        </Or>
+        <Bug category="PERFORMANCE,SECURITY" pattern="UWF_FIELD_NOT_INITIALIZED_IN_CONSTRUCTOR"/>
+    </Match>
+
+    <!-- Workaround for Cobertura generated classes -->
+    <Match>
+        <Field name="__cobertura_counters"/>
+    </Match>
+
+</FindBugsFilter>

--- a/src/main/config/owasp-dependency-checker-suppressions.xml
+++ b/src/main/config/owasp-dependency-checker-suppressions.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.2.xsd">
+    <suppress>
+        <notes><![CDATA[
+   file name: jackson-databind-2.6.7.2.jar As its used for SSM read, its not used in the main email dynamic field
+   ]]></notes>
+        <gav regex="true">^com\.fasterxml\.jackson\.core:jackson-databind:.*$</gav>
+        <cpe>cpe:/a:fasterxml:jackson-databind</cpe>
+    </suppress>
+</suppressions>

--- a/src/main/config/pmd-rules.xml
+++ b/src/main/config/pmd-rules.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0"?>
+
+<ruleset name="Custom Rules"
+         xmlns="http://pmd.sourceforge.net/ruleset/2.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://pmd.sourceforge.net/ruleset/2.0.0 http://pmd.sourceforge.net/ruleset_2_0_0.xsd">
+    <description>
+        Custom rules
+    </description>
+
+    <rule ref="category/java/bestpractices.xml">
+        <!-- The PMD mistakes the AbstractViolationReporter::log() as a debug log. -->
+        <exclude name="GuardLogStatement"/>
+        <!-- We do not care about this minor overhead, we are not Android application and we do not
+         want to change visibility of methods. Package-private visibility should be avoid almost
+         always. -->
+        <exclude name="AccessorMethodGeneration"/>
+    </rule>
+
+    <rule ref="category/java/errorprone.xml">
+        <!-- Too many false positives. -->
+        <exclude name="DataflowAnomalyAnalysis"/>
+        <!-- It is not our goal for now to keep all Serializable, maybe in the future. -->
+        <exclude name="BeanMembersShouldSerialize"/>
+    </rule>
+
+    <rule ref="category/java/multithreading.xml"></rule>
+    <rule ref="category/java/security.xml"></rule>
+    <rule ref="category/java/performance.xml"></rule>
+
+</ruleset>

--- a/src/main/config/suppressions.xml
+++ b/src/main/config/suppressions.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0"?>
+
+<!DOCTYPE suppressions PUBLIC
+        "-//Puppy Crawl//DTD Suppressions 1.1//EN"
+        "http://www.puppycrawl.com/dtds/suppressions_1_1.dtd">
+<!-- check style supression-->
+<suppressions>
+    <suppress checks=".*"
+              files="[\\/]generated-sources[\\/]"/>
+    <suppress checks=".*"
+              files="[\\/]node_modules[\\/]"/> <!-- skip nodejs -->
+    <suppress checks="MethodName"
+              files="src[\\/]test[\\/]java[\\/]"/>
+</suppressions>

--- a/src/main/java/com/loopingz/AwsSmtpRelay.java
+++ b/src/main/java/com/loopingz/AwsSmtpRelay.java
@@ -9,6 +9,7 @@ import java.nio.ByteBuffer;
 import org.apache.commons.cli.*;
 import org.apache.commons.io.IOUtils;
 import org.subethamail.smtp.RejectException;
+import org.subethamail.smtp.TooMuchDataException;
 import org.subethamail.smtp.helper.SimpleMessageListener;
 import org.subethamail.smtp.helper.SimpleMessageListenerAdapter;
 import org.subethamail.smtp.server.SMTPServer;
@@ -23,6 +24,7 @@ import com.amazonaws.services.simpleemail.model.SendRawEmailRequest;
 public class AwsSmtpRelay implements SimpleMessageListener {
 
     private static CommandLine cmd;
+    private static DeliveryDetails deliveryDetails = new DeliveryDetails();
 
     AwsSmtpRelay() {
 
@@ -34,8 +36,8 @@ public class AwsSmtpRelay implements SimpleMessageListener {
 
     public void deliver(String from, String to, InputStream inputStream) throws IOException {
         AmazonSimpleEmailService client;
-        if (cmd.hasOption("r")) {
-            client = AmazonSimpleEmailServiceClientBuilder.standard().withRegion(cmd.getOptionValue("r")).build();
+        if (deliveryDetails.hasRegion()) {
+            client = AmazonSimpleEmailServiceClientBuilder.standard().withRegion(deliveryDetails.getRegion()).build();
         } else {
             client = AmazonSimpleEmailServiceClientBuilder.standard().build();
         }
@@ -45,45 +47,81 @@ public class AwsSmtpRelay implements SimpleMessageListener {
         SendRawEmailRequest rawEmailRequest =
                 new SendRawEmailRequest(rawMessage).withSource(from)
                                                    .withDestinations(to);
-        if (cmd.hasOption("a")) {
-            rawEmailRequest = rawEmailRequest.withSourceArn(cmd.getOptionValue("a"));
+        if (deliveryDetails.hasSourceArn()) {
+            rawEmailRequest = rawEmailRequest.withSourceArn(deliveryDetails.getSourceArn());
         }
-        if (cmd.hasOption("c")) {
-            rawEmailRequest = rawEmailRequest.withConfigurationSetName(cmd.getOptionValue("c"));
+        if (deliveryDetails.hasConfiguration()) {
+            rawEmailRequest = rawEmailRequest.withConfigurationSetName(deliveryDetails.getConfiguration());
         }
         try {
             client.sendRawEmail(rawEmailRequest);
         } catch (AmazonSimpleEmailServiceException e) {
-            if(e.getErrorType() == ErrorType.Client) {
-                // If it's a client error, return a permanent error
-                throw new RejectException(e.getMessage());
-            } else {
-                throw new RejectException(451, e.getMessage());
-            }
+            throw new IOException(e.getMessage());
         }
     }
 
     void run() throws UnknownHostException {
-
-        String bindAddress = cmd.hasOption("b") ? cmd.getOptionValue("b") : "127.0.0.1";
-
-        SMTPServer smtpServer = new SMTPServer(new SimpleMessageListenerAdapter(this));
-        smtpServer.setBindAddress(InetAddress.getByName(bindAddress));
-        if (cmd.hasOption("p")) {
-            smtpServer.setPort(Integer.parseInt(cmd.getOptionValue("p")));
-        } else {
-            smtpServer.setPort(10025);
-        }
+        SMTPServer.Builder builder = new SMTPServer.Builder();
+        builder.bindAddress(InetAddress.getByName(deliveryDetails.getBindAddress()))
+            .port(deliveryDetails.getPort())
+            .simpleMessageListener(this);
+        SMTPServer smtpServer = builder.build();
         smtpServer.start();
+    }
+
+    private static void getCmdConfig() {
+        if (cmd.hasOption("b")) {
+            deliveryDetails.setBindAddress(cmd.getOptionValue("b"));
+        }
+        if (cmd.hasOption("p")) {
+            deliveryDetails.setPort(cmd.getOptionValue("p"));
+        }
+        if (cmd.hasOption("r")) {
+            deliveryDetails.setRegion(cmd.getOptionValue("r"));
+        }
+        if (cmd.hasOption("a")) {
+            deliveryDetails.setSourceArn(cmd.getOptionValue("a"));
+        }
+        if (cmd.hasOption("c")) {
+            deliveryDetails.setConfiguration(cmd.getOptionValue("c"));
+        }
+        if (cmd.hasOption("smtpO")) {
+            deliveryDetails.setSmtpOverride(cmd.getOptionValue("smtpO"));
+        }
+        if (deliveryDetails.isSmtpOverride()) {
+            if (cmd.hasOption("smtpH")) {
+                deliveryDetails.setSmtpHost(cmd.getOptionValue("smtpH"));
+            }
+            if (cmd.hasOption("smtpP")) {
+                deliveryDetails.setSmtpPort(cmd.getOptionValue("smtpP"));
+            }
+            if (cmd.hasOption("smtpU")) {
+                deliveryDetails.setSmtpUsername(cmd.getOptionValue("smtpU"));
+            }
+            if (cmd.hasOption("smtpPW")) {
+                deliveryDetails.setSmtpPassword(cmd.getOptionValue("smtpPW"));
+            }
+        }
     }
 
     public static void main(String[] args) throws UnknownHostException {
         Options options = new Options();
+        options.addOption("ssm", "ssmEnable", false, "Use SSM Parameter Store to get configuration");
+        options.addOption("ssmP", "ssmPrefix", true, "SSM prefix to find variables default is /smtpRelay");
+
         options.addOption("p", "port", true, "Port number to listen to");
         options.addOption("b", "bindAddress", true, "Address to listen to");
         options.addOption("r", "region", true, "AWS region to use");
         options.addOption("c", "configuration", true, "AWS SES configuration to use");
         options.addOption("a", "sourceArn", true, "AWS ARN of the sending authorization policy");
+
+
+        options.addOption("smtpO", "smtpOverride", true, "Not use SES but set SMTP variables true/false");
+        options.addOption("smtpH", "smtpHost", true, "SMTP variable Host");
+        options.addOption("smtpP", "smtpPort", true, "SMTP variable Port");
+        options.addOption("smtpU", "smtpUsername", true, "SMTP variable Username");
+        options.addOption("smtpPW", "smtpPassword", true, "SMTP variable password");
+
         options.addOption("h", "help", false, "Display this help");
         try {
             CommandLineParser parser = new DefaultParser();
@@ -94,8 +132,21 @@ public class AwsSmtpRelay implements SimpleMessageListener {
                 formatter.printHelp("aws-smtp-relay", options);
                 return;
             }
-            AwsSmtpRelay server = new AwsSmtpRelay();
-            server.run();
+
+            getCmdConfig();
+            //get configuration
+            if (cmd.hasOption("ssm") ){
+                deliveryDetails = new SsmConfigCollection(cmd, deliveryDetails).getConfig();
+            }
+
+            //select sender (ses or other)
+            if (deliveryDetails.isSmtpOverride()) {
+                BasicSmtpRelay server = new BasicSmtpRelay(deliveryDetails);
+                server.run();
+            } else {
+                AwsSmtpRelay server = new AwsSmtpRelay();
+                server.run();
+            }
         } catch (ParseException ex) {
             System.err.println(ex.getMessage());
         }

--- a/src/main/java/com/loopingz/AwsSmtpRelay.java
+++ b/src/main/java/com/loopingz/AwsSmtpRelay.java
@@ -2,19 +2,18 @@ package com.loopingz;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.lang.invoke.MethodHandles;
 import java.net.InetAddress;
 import java.net.UnknownHostException;
 import java.nio.ByteBuffer;
 
 import org.apache.commons.cli.*;
 import org.apache.commons.io.IOUtils;
-import org.subethamail.smtp.RejectException;
-import org.subethamail.smtp.TooMuchDataException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.subethamail.smtp.helper.SimpleMessageListener;
-import org.subethamail.smtp.helper.SimpleMessageListenerAdapter;
 import org.subethamail.smtp.server.SMTPServer;
 
-import com.amazonaws.AmazonServiceException.ErrorType;
 import com.amazonaws.services.simpleemail.AmazonSimpleEmailService;
 import com.amazonaws.services.simpleemail.AmazonSimpleEmailServiceClientBuilder;
 import com.amazonaws.services.simpleemail.model.AmazonSimpleEmailServiceException;
@@ -23,17 +22,20 @@ import com.amazonaws.services.simpleemail.model.SendRawEmailRequest;
 
 public class AwsSmtpRelay implements SimpleMessageListener {
 
+    private static final Logger LOG = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+
     private static CommandLine cmd;
     private static DeliveryDetails deliveryDetails = new DeliveryDetails();
 
     AwsSmtpRelay() {
-
     }
 
+    @Override
     public boolean accept(String from, String to) {
         return true;
     }
 
+    @Override
     public void deliver(String from, String to, InputStream inputStream) throws IOException {
         AmazonSimpleEmailService client;
         if (deliveryDetails.hasRegion()) {
@@ -56,7 +58,7 @@ public class AwsSmtpRelay implements SimpleMessageListener {
         try {
             client.sendRawEmail(rawEmailRequest);
         } catch (AmazonSimpleEmailServiceException e) {
-            throw new IOException(e.getMessage());
+            throw new IOException(e.getMessage(), e);
         }
     }
 
@@ -115,7 +117,6 @@ public class AwsSmtpRelay implements SimpleMessageListener {
         options.addOption("c", "configuration", true, "AWS SES configuration to use");
         options.addOption("a", "sourceArn", true, "AWS ARN of the sending authorization policy");
 
-
         options.addOption("smtpO", "smtpOverride", true, "Not use SES but set SMTP variables true/false");
         options.addOption("smtpH", "smtpHost", true, "SMTP variable Host");
         options.addOption("smtpP", "smtpPort", true, "SMTP variable Port");
@@ -135,7 +136,7 @@ public class AwsSmtpRelay implements SimpleMessageListener {
 
             getCmdConfig();
             //get configuration
-            if (cmd.hasOption("ssm") ){
+            if (cmd.hasOption("ssm")) {
                 deliveryDetails = new SsmConfigCollection(cmd, deliveryDetails).getConfig();
             }
 
@@ -148,7 +149,7 @@ public class AwsSmtpRelay implements SimpleMessageListener {
                 server.run();
             }
         } catch (ParseException ex) {
-            System.err.println(ex.getMessage());
+            LOG.error(ex.getMessage(), ex);
         }
     }
 }

--- a/src/main/java/com/loopingz/BasicSmtpRelay.java
+++ b/src/main/java/com/loopingz/BasicSmtpRelay.java
@@ -1,9 +1,7 @@
 package com.loopingz;
 
-
 import com.amazonaws.util.StringUtils;
 import org.subethamail.smtp.helper.SimpleMessageListener;
-import org.subethamail.smtp.helper.SimpleMessageListenerAdapter;
 import org.subethamail.smtp.server.SMTPServer;
 
 import javax.mail.*;
@@ -38,10 +36,12 @@ public class BasicSmtpRelay implements SimpleMessageListener {
         }
     }
 
+    @Override
     public boolean accept(String from, String to) {
         return true;
     }
 
+    @Override
     public void deliver(String from, String to, InputStream inputStream) throws IOException {
 
         try {
@@ -52,8 +52,8 @@ public class BasicSmtpRelay implements SimpleMessageListener {
             msg.setFrom(new InternetAddress(from));
 
             Transport.send(msg);
-        } catch (MessagingException ex){
-            throw new IOException(ex.getMessage());
+        } catch (MessagingException ex) {
+            throw new IOException(ex.getMessage(), ex);
         }
     }
 
@@ -61,6 +61,7 @@ public class BasicSmtpRelay implements SimpleMessageListener {
         if (authRequest) {
             return Session.getDefaultInstance(props,
                     new Authenticator() {
+                        @Override
                         protected PasswordAuthentication getPasswordAuthentication() {
                             return new PasswordAuthentication(deliveryDetails.getSmtpUsername(), deliveryDetails.getSmtpPassword());
                         }
@@ -68,7 +69,6 @@ public class BasicSmtpRelay implements SimpleMessageListener {
         }
         return Session.getDefaultInstance(props);
     }
-
 
     void run() throws UnknownHostException {
         SMTPServer.Builder builder = new SMTPServer.Builder();
@@ -78,6 +78,4 @@ public class BasicSmtpRelay implements SimpleMessageListener {
         SMTPServer smtpServer = builder.build();
         smtpServer.start();
     }
-
-
 }

--- a/src/main/java/com/loopingz/BasicSmtpRelay.java
+++ b/src/main/java/com/loopingz/BasicSmtpRelay.java
@@ -1,0 +1,83 @@
+package com.loopingz;
+
+
+import com.amazonaws.util.StringUtils;
+import org.subethamail.smtp.helper.SimpleMessageListener;
+import org.subethamail.smtp.helper.SimpleMessageListenerAdapter;
+import org.subethamail.smtp.server.SMTPServer;
+
+import javax.mail.*;
+import javax.mail.internet.InternetAddress;
+import javax.mail.internet.MimeMessage;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+import java.util.Properties;
+
+public class BasicSmtpRelay implements SimpleMessageListener {
+
+    private DeliveryDetails deliveryDetails;
+    private Properties props;
+    private boolean authRequest;
+
+    BasicSmtpRelay(DeliveryDetails deliveryDetails) {
+        this.deliveryDetails = deliveryDetails;
+
+        props = new Properties();
+        props.put("mail.smtp.starttls.enable", "true");
+        props.put("mail.smtp.host", deliveryDetails.getSmtpHost());
+        props.put("mail.smtp.port", deliveryDetails.getSmtpPort());
+
+        if (!StringUtils.isNullOrEmpty(deliveryDetails.getSmtpUsername()) && !StringUtils.isNullOrEmpty(deliveryDetails.getSmtpPassword())) {
+            props.put("mail.smtp.auth", "true");
+            authRequest = true;
+        } else {
+            props.put("mail.smtp.auth", "false");
+            authRequest = false;
+        }
+    }
+
+    public boolean accept(String from, String to) {
+        return true;
+    }
+
+    public void deliver(String from, String to, InputStream inputStream) throws IOException {
+
+        try {
+            Session session = getSession();
+            Message msg = new MimeMessage(session, inputStream);
+            msg.setFrom();
+            msg.setRecipient(Message.RecipientType.TO, new InternetAddress(to));
+            msg.setFrom(new InternetAddress(from));
+
+            Transport.send(msg);
+        } catch (MessagingException ex){
+            throw new IOException(ex.getMessage());
+        }
+    }
+
+    private Session getSession() {
+        if (authRequest) {
+            return Session.getDefaultInstance(props,
+                    new Authenticator() {
+                        protected PasswordAuthentication getPasswordAuthentication() {
+                            return new PasswordAuthentication(deliveryDetails.getSmtpUsername(), deliveryDetails.getSmtpPassword());
+                        }
+                    });
+        }
+        return Session.getDefaultInstance(props);
+    }
+
+
+    void run() throws UnknownHostException {
+        SMTPServer.Builder builder = new SMTPServer.Builder();
+        builder.bindAddress(InetAddress.getByName(deliveryDetails.getBindAddress()))
+                .port(deliveryDetails.getPort())
+                .simpleMessageListener(this);
+        SMTPServer smtpServer = builder.build();
+        smtpServer.start();
+    }
+
+
+}

--- a/src/main/java/com/loopingz/DeliveryDetails.java
+++ b/src/main/java/com/loopingz/DeliveryDetails.java
@@ -2,8 +2,11 @@ package com.loopingz;
 
 import com.amazonaws.util.StringUtils;
 
+import java.net.InetAddress;
+
 public class DeliveryDetails {
 
+    private static final int DEFAULT_PORT = 10025;
     private String bindAddress;
     private String port;
 
@@ -19,7 +22,7 @@ public class DeliveryDetails {
 
     public String getBindAddress() {
         if (StringUtils.isNullOrEmpty(bindAddress)) {
-            return  "127.0.0.1";
+            return InetAddress.getLoopbackAddress().getHostAddress();
         }
         return bindAddress;
     }
@@ -29,8 +32,8 @@ public class DeliveryDetails {
     }
 
     public int getPort() {
-        if (StringUtils.isNullOrEmpty(port)){
-            return 10025;
+        if (StringUtils.isNullOrEmpty(port)) {
+            return DEFAULT_PORT;
         }
         return Integer.parseInt(port);
     }
@@ -81,9 +84,8 @@ public class DeliveryDetails {
 
     //if starts with t its true, else we don't override
     public boolean isSmtpOverride() {
-        return
-                !StringUtils.isNullOrEmpty(smtpHost) &&
-                StringUtils.beginsWithIgnoreCase(smtpOverride, "t");
+        return !StringUtils.isNullOrEmpty(smtpHost)
+                && StringUtils.beginsWithIgnoreCase(smtpOverride, "t");
     }
 
     public void setSmtpOverride(String smtpOverride) {

--- a/src/main/java/com/loopingz/DeliveryDetails.java
+++ b/src/main/java/com/loopingz/DeliveryDetails.java
@@ -1,0 +1,124 @@
+package com.loopingz;
+
+import com.amazonaws.util.StringUtils;
+
+public class DeliveryDetails {
+
+    private String bindAddress;
+    private String port;
+
+    private String region;
+    private String configuration;
+
+    private String sourceArn;
+    private String smtpOverride;
+    private String smtpHost;
+    private String smtpPort;
+    private String smtpUsername;
+    private String smtpPassword;
+
+    public String getBindAddress() {
+        if (StringUtils.isNullOrEmpty(bindAddress)) {
+            return  "127.0.0.1";
+        }
+        return bindAddress;
+    }
+
+    public void setBindAddress(String bindAddress) {
+        this.bindAddress = bindAddress;
+    }
+
+    public int getPort() {
+        if (StringUtils.isNullOrEmpty(port)){
+            return 10025;
+        }
+        return Integer.parseInt(port);
+    }
+
+    public void setPort(String port) {
+        this.port = port;
+    }
+
+    public String getRegion() {
+        return region;
+    }
+
+    public void setRegion(String region) {
+        this.region = region;
+    }
+
+    public boolean hasRegion() {
+        return !StringUtils.isNullOrEmpty(region);
+    }
+
+    public String getConfiguration() {
+        return configuration;
+    }
+
+    public void setConfiguration(String configuration) {
+        this.configuration = configuration;
+    }
+
+    public boolean hasConfiguration() {
+        return !StringUtils.isNullOrEmpty(configuration);
+    }
+
+    public String getSourceArn() {
+        return sourceArn;
+    }
+
+    public boolean hasSourceArn() {
+        return !StringUtils.isNullOrEmpty(sourceArn);
+    }
+
+    public void setSourceArn(String sourceArn) {
+        this.sourceArn = sourceArn;
+    }
+
+    public String getSmtpOverride() {
+        return smtpOverride;
+    }
+
+    //if starts with t its true, else we don't override
+    public boolean isSmtpOverride() {
+        return
+                !StringUtils.isNullOrEmpty(smtpHost) &&
+                StringUtils.beginsWithIgnoreCase(smtpOverride, "t");
+    }
+
+    public void setSmtpOverride(String smtpOverride) {
+        this.smtpOverride = smtpOverride;
+    }
+
+    public String getSmtpHost() {
+        return smtpHost;
+    }
+
+    public void setSmtpHost(String smtpHost) {
+        this.smtpHost = smtpHost;
+    }
+
+    public String getSmtpPort() {
+        return smtpPort;
+    }
+
+    public void setSmtpPort(String smtpPort) {
+        this.smtpPort = smtpPort;
+    }
+
+    public String getSmtpUsername() {
+        return smtpUsername;
+    }
+
+    public void setSmtpUsername(String smtpUsername) {
+        this.smtpUsername = smtpUsername;
+    }
+
+    public String getSmtpPassword() {
+        return smtpPassword;
+    }
+
+    public void setSmtpPassword(String smtpPassword) {
+        this.smtpPassword = smtpPassword;
+    }
+}

--- a/src/main/java/com/loopingz/SsmConfigCollection.java
+++ b/src/main/java/com/loopingz/SsmConfigCollection.java
@@ -9,7 +9,6 @@ import com.amazonaws.services.simplesystemsmanagement.model.AWSSimpleSystemsMana
 import com.amazonaws.services.simplesystemsmanagement.model.GetParametersByPathRequest;
 import com.amazonaws.services.simplesystemsmanagement.model.GetParametersByPathResult;
 import com.amazonaws.services.simplesystemsmanagement.model.Parameter;
-import com.amazonaws.util.StringUtils;
 import org.apache.commons.cli.CommandLine;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -18,7 +17,7 @@ import java.lang.invoke.MethodHandles;
 
 public class SsmConfigCollection {
 
-    Logger log = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+    private static final Logger LOG = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
     private CommandLine cmd;
     private DeliveryDetails deliveryDetails;
@@ -39,11 +38,11 @@ public class SsmConfigCollection {
             GetParametersByPathRequest parameterRequest = new GetParametersByPathRequest();
             parameterRequest.withPath(prefix).withRecursive(true).setWithDecryption(true);
             GetParametersByPathResult parameterResult = simpleSystemsManagementClient.getParametersByPath(parameterRequest);
-            log.trace("length is: " + parameterResult.getParameters().size());
+            LOG.trace("length is: " + parameterResult.getParameters().size());
             for (Parameter param : parameterResult.getParameters()) {
                 String key = param.getName();
                 String value = param.getValue();
-                log.trace("key is: " + key +" value: " + value);
+                LOG.trace("key is: " + key + " value: " + value);
                 if (key.endsWith("/region")) {
                     deliveryDetails.setRegion(value);
                 } else if (key.endsWith("/configuration")) {
@@ -61,7 +60,6 @@ public class SsmConfigCollection {
                 } else if (key.endsWith("/smtpPassword")) {
                     deliveryDetails.setSmtpPassword(value);
                 }
-
             }
         } catch (AWSSimpleSystemsManagementException e) {
             throw new RuntimeException("Failed to pass SSM arguments", e);

--- a/src/main/java/com/loopingz/SsmConfigCollection.java
+++ b/src/main/java/com/loopingz/SsmConfigCollection.java
@@ -1,0 +1,71 @@
+package com.loopingz;
+
+import com.amazonaws.auth.AWSCredentialsProvider;
+import com.amazonaws.auth.InstanceProfileCredentialsProvider;
+import com.amazonaws.regions.Regions;
+import com.amazonaws.services.simplesystemsmanagement.AWSSimpleSystemsManagement;
+import com.amazonaws.services.simplesystemsmanagement.AWSSimpleSystemsManagementClientBuilder;
+import com.amazonaws.services.simplesystemsmanagement.model.AWSSimpleSystemsManagementException;
+import com.amazonaws.services.simplesystemsmanagement.model.GetParametersByPathRequest;
+import com.amazonaws.services.simplesystemsmanagement.model.GetParametersByPathResult;
+import com.amazonaws.services.simplesystemsmanagement.model.Parameter;
+import com.amazonaws.util.StringUtils;
+import org.apache.commons.cli.CommandLine;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.lang.invoke.MethodHandles;
+
+public class SsmConfigCollection {
+
+    Logger log = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+
+    private CommandLine cmd;
+    private DeliveryDetails deliveryDetails;
+
+    public SsmConfigCollection(CommandLine cmd, DeliveryDetails deliveryDetails) {
+        this.cmd = cmd;
+        this.deliveryDetails = deliveryDetails;
+    }
+
+    public DeliveryDetails getConfig() {
+        String prefix = (cmd.hasOption("ssmP") ? cmd.getOptionValue("ssmP") : "/smtpRelay/");
+
+        try {
+            AWSCredentialsProvider credentials = InstanceProfileCredentialsProvider.getInstance();
+            AWSSimpleSystemsManagement simpleSystemsManagementClient =
+                    AWSSimpleSystemsManagementClientBuilder.standard().withCredentials(credentials).withRegion(Regions.getCurrentRegion().getName()).build();
+
+            GetParametersByPathRequest parameterRequest = new GetParametersByPathRequest();
+            parameterRequest.withPath(prefix).withRecursive(true).setWithDecryption(true);
+            GetParametersByPathResult parameterResult = simpleSystemsManagementClient.getParametersByPath(parameterRequest);
+            log.trace("length is: " + parameterResult.getParameters().size());
+            for (Parameter param : parameterResult.getParameters()) {
+                String key = param.getName();
+                String value = param.getValue();
+                log.trace("key is: " + key +" value: " + value);
+                if (key.endsWith("/region")) {
+                    deliveryDetails.setRegion(value);
+                } else if (key.endsWith("/configuration")) {
+                    deliveryDetails.setConfiguration(value);
+                } else if (key.endsWith("/sourceArn")) {
+                    deliveryDetails.setSourceArn(value);
+                } else if (key.endsWith("/smtpOverride")) {
+                    deliveryDetails.setSmtpOverride(value);
+                } else if (key.endsWith("/smtpHost")) {
+                    deliveryDetails.setSmtpHost(value);
+                } else if (key.endsWith("/smtpPort")) {
+                    deliveryDetails.setSmtpPort(value);
+                } else if (key.endsWith("/smtpUsername")) {
+                    deliveryDetails.setSmtpUsername(value);
+                } else if (key.endsWith("/smtpPassword")) {
+                    deliveryDetails.setSmtpPassword(value);
+                }
+
+            }
+        } catch (AWSSimpleSystemsManagementException e) {
+            throw new RuntimeException("Failed to pass SSM arguments", e);
+        }
+        return deliveryDetails;
+    }
+}


### PR DESCRIPTION
Changes proposed in this pull request:

- Add smtp Override functionality to use BasicSmtpRelay if not in SES mode
- Add SSM paramater store config so only port and host just need to be configured on the box.
- Update to not include dynamodb (replaced with ssm component)
- Update AWS sdk from 1.11.449 to 1.11.517
- Update subethasmtp to use more update to date version at com.github.davidmoten:subethasmtp:4.0-RC8 (last update Jun, 2018 vs Jun, 2012)
- Get variables from cmd object into DeliveryDetails so that SSM params can override it as well as pass to smtpBasicRelay
- Clean up pom file
- Make min java version 1.8

This has been tested and is being rolled out by my area on a new product we will be releasing shortly. Having the ability to switch from ses to a fake smtp server without changing what is installed on the servers is very handy.

----

Added the following arguments
```
 -smtpH,--smtpHost <arg>        SMTP variable Host
 -smtpO,--smtpOverride <arg>    Not use SES but set SMTP variables
                                true/false
 -smtpP,--smtpPort <arg>        SMTP variable Port
 -smtpPW,--smtpPassword <arg>   SMTP variable password
 -smtpU,--smtpUsername <arg>    SMTP variable Username
 -ssm,--ssmEnable               Use SSM to get configuration
 -ssmP,--ssmPrefix <arg>        SSM prefix to find variables default is
                                /smtpRelay
```

If ssm (Simple Systems Manager) Parameter store is used please add to your region https://ap-southeast-2.console.aws.amazon.com/systems-manager/parameters once setup, you can change the configuration by restarting the service or rebooting the ec2 instance

                /smtpRelay/region 
                /smtpRelay/configuration 
                /smtpRelay/sourceArn 
                /smtpRelay/smtpOverride
                /smtpRelay/smtpHost
                /smtpRelay/smtpPort
                /smtpRelay/smtpUsername
                /smtpRelay/smtpPassword
"/smtpRelay" can be changed with -ssmP


smtpOverride allows you to point it to a mail catcher such as [MailHog](https://github.com/mailhog/MailHog/) to disable outbound email


## IAM Policy for SSM Paramater store access

Use this IAM Policy JSON to allow SSM Paramater variables to be used instead of the command line
Replace $SSMKEY with KMS key arn for the alias aws/ssm i.e. arn:aws:kms:ap-southeast-2:111222333444:key/111111111-2222-3333-4444-555555555555

```
{
  "Statement": [
    {
      "Effect": "Allow",
      "Action": [
        "ssm:DescribeParameters"
      ],
      "Resource": "*"
    },
    {
      "Effect": "Allow",
      "Action": [
        "ssm:GetParameters",
        "ssm:GetParameter",
        "ssm:GetParametersByPath"
      ],
      "Resource": [
        "arn:aws:ssm:*:*:parameter/smtpRelay",
        "arn:aws:ssm:*:*:parameter/smtpRelay/*"
      ]
    },
    {
      "Effect": "Allow",
      "Action": [
        "kms:Decrypt"
      ],
      "Resource": [
        "$SSMKEY"
      ]
    }
  ]
}
```