### PR TITLE
Update AWS java SDK version to latest

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM openjdk:jre-alpine
-MAINTAINER Damien Metzler <dmetzler@nuxeo.com>
-MAINTAINER Remi Cattiau <remi@cattiau.com>
-MAINTAINER Morgan Christiansson <docker@mog.se>
+LABEL maintainer="Damien Metzler <dmetzler@nuxeo.com>"
+LABEL maintainer="Remi Cattiau <remi@cattiau.com>"
+LABEL maintainer="Morgan Christiansson <docker@mog.se>"
 
 ADD target/*-jar-with-dependencies.jar /usr/share/aws-smtp-relay/aws-smtp-relay.jar
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,3 @@
-> FORKED from loopingz/aws-smtp-relay
-
 # aws-smtp-relay
 ![logo](https://raw.githubusercontent.com/8llouch/aws-smtp-relay/master/docs/aws-smtp-relay-logo.png)
 

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+> FORKED from loopingz/aws-smtp-relay
+
 # aws-smtp-relay
 ![logo](https://raw.githubusercontent.com/8llouch/aws-smtp-relay/master/docs/aws-smtp-relay-logo.png)
 

--- a/pom.xml
+++ b/pom.xml
@@ -5,14 +5,14 @@
 
     <groupId>com.loopingz</groupId>
     <artifactId>aws-smtp-relay</artifactId>
-    <version>1.3.0</version>
+    <version>1.4.0</version>
 
     <dependencyManagement>
         <dependencies>
             <dependency>
                 <groupId>com.amazonaws</groupId>
                 <artifactId>aws-java-sdk-bom</artifactId>
-                <version>1.11.449</version>
+                <version>1.11.838</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
@@ -34,12 +34,12 @@
         <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>aws-java-sdk-dynamodb</artifactId>
-            <version>1.11.564</version>
+            <version>1.11.838</version>
         </dependency>
         <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>aws-java-sdk-ses</artifactId>
-            <version>1.11.564</version>
+            <version>1.11.838</version>
         </dependency>
         <dependency>
             <groupId>com.sun.mail</groupId>


### PR DESCRIPTION
Refreshing the SDK versions so that we can leverage some newer functionality (such as IAM role service accounts). The SDK bumps are for minor versions, and so did a minor version upgrade for this package as well from 1.3.0 to 1.4.0.

While here, I noticed that the Dockerfile made use of the deprecated `MAINTAINER` instruction; changed that to `LABEL` per https://docs.docker.com/engine/reference/builder/#maintainer-deprecated


Thanks,
Hari.